### PR TITLE
fix(layout): switch shiki to dual themes for readable code blocks

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -9,5 +9,11 @@ export default defineConfig({
 		imageService: "compile",
 	}),
 	integrations: [mdx(), sitemap()],
+	markdown: {
+		shikiConfig: {
+			themes: { light: "github-light", dark: "github-dark" },
+			defaultColor: false,
+		},
+	},
 	site: "https://agentic-journal-production.pm-lemeliner.workers.dev",
 });

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -75,6 +75,17 @@ const hasHeadSlot = Astro.slots.has("head");
 			h1, h2, h3 { line-height: 1.2; }
 			code { background: var(--code-bg); padding: 0.1em 0.3em; border-radius: 3px; }
 			pre { background: var(--code-bg); padding: 1rem; overflow-x: auto; border-radius: 4px; }
+			pre, pre code { background: var(--code-bg); }
+			[data-theme="light"] .astro-code,
+			[data-theme="light"] .astro-code span {
+				color: var(--shiki-light) !important;
+				background-color: var(--code-bg) !important;
+			}
+			[data-theme="dark"] .astro-code,
+			[data-theme="dark"] .astro-code span {
+				color: var(--shiki-dark) !important;
+				background-color: var(--code-bg) !important;
+			}
 			header, footer { color: var(--muted); font-size: 0.9rem; margin: 2rem 0; }
 			header.site-header {
 				display: flex;


### PR DESCRIPTION
## Summary
- Default Shiki theme `github-dark` rendered light token colors against the light `--code-bg` (#eee), making fenced code blocks unreadable in light mode (e.g. the ASCII tables in `tdd-importance.mdx`).
- Configure dual themes (`github-light` + `github-dark`) with `defaultColor: false` so Shiki emits `--shiki-light` / `--shiki-dark` CSS vars.
- Select the right var per `[data-theme]` in `BaseLayout.astro` so code blocks track the site theme.

## Test plan
- [ ] `bun run build` completes
- [ ] Visit `/posts/tdd-importance` in light mode — ASCII code blocks readable (dark text on light bg)
- [ ] Toggle dark mode — same blocks readable (light text on dark bg)
- [ ] Verify other posts with code blocks (`evals-importance`, `harness-self-improvement`) render correctly in both themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)