### PR TITLE
chore: add @claude-mention responder workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,40 @@
+name: Claude
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: '--allowedTools "Bash(git:*),Bash(gh:*),Bash(npm:*),Bash(npx:*),Bash(node:*),Bash(bun:*),Edit,Write,Read,Glob,Grep"'
+          show_full_output: "true"

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -51,6 +51,9 @@ jobs:
               body,
             });
 
+      - name: Install Playwright browsers
+        run: bunx playwright install --with-deps chromium
+
       - name: Playwright e2e against preview
         run: bun run playwright test
         env:


### PR DESCRIPTION
## Summary

Adds `.github/workflows/claude.yml` to handle @claude mentions in issue comments, PR review comments, and PR reviews. Uses `anthropics/claude-code-action@v1` with `CLAUDE_CODE_OAUTH_TOKEN`.

## Why no `issues` trigger?

The new spec 049 pipeline (PR #52, branch `spec/issue-to-pr-pipeline`) introduces `bootstrap.yml` which owns `issues.opened|edited`. Including `issues` here would double-fire on every new issue.

Split of responsibility:
- `bootstrap.yml` (spec 049) — every new issue → spec scaffold pipeline
- `claude.yml` (this PR) — @claude mentions on issue/PR comments and reviews

## Test plan
- [ ] Comment `@claude what does this PR do?` on any open PR → workflow fires
- [ ] Open a new issue → only `bootstrap.yml` fires (verify no double-trigger)

🤖 Generated with [Claude Code](https://claude.com/claude-code)