### PR TITLE
fix: switch pipeline auth to CLAUDE_CODE_OAUTH_TOKEN (drop API key)

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Run /do-auto aligner
         id: align
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           ISSUE_BODY: ${{ github.event.issue.body }}
         run: |
           claude -p "/do-auto $ISSUE_BODY" || true

--- a/.github/workflows/slice.yml
+++ b/.github/workflows/slice.yml
@@ -79,7 +79,7 @@ jobs:
             --skill expertise \
             "You are the spec-implementer. Make slice ${SLICE_ID} of spec ${SPEC_ID} GREEN. Read the frozen gate and implement only the file_targets declared in task ${SLICE_ID}. Run bun run tasks:verify. When GREEN, run a refactor pass scoped to the task's file_targets. Do not push — only commit."
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           GH_TOKEN: ${{ github.token }}
 
       - name: Commit implemented slice files
@@ -119,7 +119,7 @@ jobs:
             --max-turns 10 \
             "You are the spec-replanner. Slice ${SLICE_ID} of spec ${SPEC_ID} is now GREEN on branch ${BRANCH}. Review tasks.md and update the plan: check which slices are unblocked, update depends_on status, and commit any changes to tasks.md."
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           GH_TOKEN: ${{ github.token }}
 
       - name: Failure escalation — post menu on issue

--- a/tests/workflows/bootstrap.test.ts
+++ b/tests/workflows/bootstrap.test.ts
@@ -7,7 +7,7 @@
  *   3. Permissions block: contents:write, pull-requests:write, issues:write
  *   4. Job creates branch named auto/<issue-number>-<slug> from main
  *   5. Job opens a draft PR linked to the issue (gh pr create --draft)
- *   6. Job invokes `claude -p` with /do-auto and uses ANTHROPIC_API_KEY secret
+ *   6. Job invokes `claude -p` with /do-auto and uses CLAUDE_CODE_OAUTH_TOKEN secret
  *   7. After claude runs, checks .agentic/last-alignment.md confidence:
  *      - confidence:low  → posts issue comment (does NOT commit alignment)
  *      - confidence:high → commits alignment.md to the branch (ONLY when high)
@@ -243,7 +243,7 @@ describe("bootstrap.yml: draft PR creation", () => {
 });
 
 // ---------------------------------------------------------------------------
-// 6. Claude invocation with /do-auto and ANTHROPIC_API_KEY
+// 6. Claude invocation with /do-auto and CLAUDE_CODE_OAUTH_TOKEN
 // ---------------------------------------------------------------------------
 
 describe("bootstrap.yml: claude /do-auto invocation", () => {
@@ -261,9 +261,10 @@ describe("bootstrap.yml: claude /do-auto invocation", () => {
 		expect(doAutoStep).toBeDefined();
 	});
 
-	test("uses ANTHROPIC_API_KEY secret", () => {
+	test("uses CLAUDE_CODE_OAUTH_TOKEN secret (no API key)", () => {
 		const raw = readWorkflowRaw();
-		expect(raw).toMatch(/secrets\.ANTHROPIC_API_KEY/);
+		expect(raw).toMatch(/secrets\.CLAUDE_CODE_OAUTH_TOKEN/);
+		expect(raw).not.toMatch(/secrets\.ANTHROPIC_API_KEY/);
 	});
 
 	test("threads the issue body into the claude invocation", () => {

--- a/tests/workflows/slice.test.ts
+++ b/tests/workflows/slice.test.ts
@@ -12,7 +12,7 @@
  *   6.  Runner: ubuntu-latest
  *   7.  Checkout: actions/checkout@v4 checks out branch with fetch-depth: 0
  *   8.  Pull-rebase before work
- *   9.  Claude invocation: claude -p with --max-turns, ANTHROPIC_API_KEY,
+ *   9.  Claude invocation: claude -p with --max-turns, CLAUDE_CODE_OAUTH_TOKEN,
  *       --no-resume, and expertise skill loaded via flag/path/env mechanism
  *  10.  Commit step between pull-rebase and push
  *  11.  Push with retry on non-fast-forward (max retries = 3)
@@ -374,7 +374,7 @@ describe("slice.yml: pull-rebase before work", () => {
 });
 
 // ---------------------------------------------------------------------------
-// 9. Claude invocation: -p, --max-turns, ANTHROPIC_API_KEY, expertise skill, --no-resume
+// 9. Claude invocation: -p, --max-turns, CLAUDE_CODE_OAUTH_TOKEN, expertise skill, --no-resume
 // ---------------------------------------------------------------------------
 
 describe("slice.yml: claude invocation", () => {
@@ -392,17 +392,20 @@ describe("slice.yml: claude invocation", () => {
 		expect(claudeStep?.run).toMatch(/--max-turns/);
 	});
 
-	test("uses ANTHROPIC_API_KEY secret", () => {
+	test("uses CLAUDE_CODE_OAUTH_TOKEN secret (no API key)", () => {
 		const raw = readWorkflowRaw();
-		expect(raw).toMatch(/secrets\.ANTHROPIC_API_KEY/);
+		expect(raw).toMatch(/secrets\.CLAUDE_CODE_OAUTH_TOKEN/);
+		expect(raw).not.toMatch(/secrets\.ANTHROPIC_API_KEY/);
 	});
 
-	test("ANTHROPIC_API_KEY is wired into the claude step (env or run block)", () => {
+	test("CLAUDE_CODE_OAUTH_TOKEN is wired into the claude step (env or run block)", () => {
 		const wf = parseWorkflow();
 		const steps = allSteps(wf);
 		const claudeStep = steps.find((s) => s.run?.match(/claude\s+-p/));
-		const envHasKey = Object.keys(claudeStep?.env ?? {}).some((k) => k === "ANTHROPIC_API_KEY");
-		const runHasKey = claudeStep?.run?.includes("ANTHROPIC_API_KEY") ?? false;
+		const envHasKey = Object.keys(claudeStep?.env ?? {}).some(
+			(k) => k === "CLAUDE_CODE_OAUTH_TOKEN",
+		);
+		const runHasKey = claudeStep?.run?.includes("CLAUDE_CODE_OAUTH_TOKEN") ?? false;
 		expect(envHasKey || runHasKey).toBe(true);
 	});
 
@@ -611,7 +614,7 @@ describe("slice.yml: failure escalation — posts to ISSUE (not PR)", () => {
 		const steps = allSteps(wf);
 		const menuStep = steps.find((s) => s.run?.includes("issue-options"));
 		const envHasToken = Object.keys(menuStep?.env ?? {}).some(
-			(k) => k === "GH_TOKEN" || k === "GITHUB_TOKEN" || k === "ANTHROPIC_API_KEY",
+			(k) => k === "GH_TOKEN" || k === "GITHUB_TOKEN" || k === "CLAUDE_CODE_OAUTH_TOKEN",
 		);
 		const runHasToken =
 			menuStep?.run?.includes("GH_TOKEN") ||


### PR DESCRIPTION
## Summary

The newly merged spec 049 pipeline (`bootstrap.yml`, `slice.yml`) used `secrets.ANTHROPIC_API_KEY` for `claude -p`. Repo standard is OAuth (`CLAUDE_CODE_OAUTH_TOKEN`, used by `claude.yml`/`claude-code-action@v1`). This PR drops the API key entirely.

## Changes

- `.github/workflows/bootstrap.yml`: env swap (1 occurrence)
- `.github/workflows/slice.yml`: env swap (2 occurrences)
- `tests/workflows/bootstrap.test.ts`: gate now asserts OAuth token present **and** API key absent (regression-proof)
- `tests/workflows/slice.test.ts`: same assertion plus the failure-menu env check now allows OAuth token instead of API key

## Test plan
- [x] `bun test tests/workflows/*.test.ts tests/automation-pipeline.test.ts` → 127/127 ✓
- [ ] CI green
- [ ] Open a test issue post-merge → bootstrap fires using OAuth

🤖 Generated with [Claude Code](https://claude.com/claude-code)