### PR TITLE
fix(bootstrap): seed branch with empty commit before opening PR

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -35,10 +35,13 @@ jobs:
             | cut -c1-50)
           echo "value=$SLUG" >> $GITHUB_OUTPUT
 
-      - name: Create branch
+      - name: Create branch with seed commit
         run: |
           BRANCH="auto/${{ github.event.issue.number }}-${{ steps.slug.outputs.value }}"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
           git checkout -b "$BRANCH"
+          git commit --allow-empty -m "bootstrap: open PR for issue #${{ github.event.issue.number }}"
           git push -u origin "$BRANCH"
 
       - name: Open draft PR linked to issue

--- a/tests/workflows/bootstrap.test.ts
+++ b/tests/workflows/bootstrap.test.ts
@@ -304,11 +304,11 @@ describe("bootstrap.yml: confidence gate (structural)", () => {
 	test("the alignment.md commit step has an 'if:' guard referencing confidence", () => {
 		const wf = parseWorkflow();
 		const steps = allSteps(wf);
-		// Find a step that commits alignment.md
+		// Find the step that commits alignment.md (must reference alignment.md explicitly)
 		const commitStep = steps.find(
 			(s) =>
 				s.run !== undefined &&
-				(s.run.includes("alignment.md") || s.run.includes("git commit")) &&
+				s.run.includes("alignment.md") &&
 				(s.run.includes("git add") || s.run.includes("git commit")),
 		);
 		expect(commitStep).toBeDefined();


### PR DESCRIPTION
## Summary

`gh pr create` was failing with `No commits between main and auto/<n>` because the bootstrap.yml flow opened the PR immediately after creating the branch — before any commit landed.

Fix: an empty `git commit --allow-empty` lands on the new branch before `gh pr create` runs. The PR now has a guaranteed diff regardless of whether the aligner step succeeds.

Also tightens the alignment-commit gate test so the seed-commit step doesn't match the assertion looking for the alignment-commit step.

## Test plan
- [x] `bun test tests/workflows/bootstrap.test.ts` 31/31 ✓
- [ ] Edit issue #55 → bootstrap completes through PR creation