### PR TITLE
fix: install Claude CLI in bootstrap + slice runners

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -53,6 +53,14 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Setup Node and install Claude Code CLI
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install @anthropic-ai/claude-code
+        run: npm i -g @anthropic-ai/claude-code
+
       - name: Run /do-auto aligner
         id: align
         env:

--- a/.github/workflows/slice.yml
+++ b/.github/workflows/slice.yml
@@ -63,6 +63,14 @@ jobs:
           curl -fsSL https://bun.sh/install | bash
           echo "$HOME/.bun/bin" >> "$GITHUB_PATH"
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install @anthropic-ai/claude-code
+        run: npm i -g @anthropic-ai/claude-code
+
       - name: Install dependencies
         run: |
           export PATH="$HOME/.bun/bin:$PATH"


### PR DESCRIPTION
## Summary

`claude -p` failed with `command not found` on the GitHub runner because the CLI isn't pre-installed. The aligner's `|| true` swallowed the error → low-confidence branch fired → bot posted clarification comment, never wrote alignment.md.

Adds `actions/setup-node@v4` + `npm i -g @anthropic-ai/claude-code` before any `claude -p` invocation.

## Test plan
- [x] `bun test tests/workflows/{bootstrap,slice}.test.ts` 80/80 ✓
- [ ] Edit issue #55 → claude actually runs, alignment.md commits, PR populates

🤖 Generated with [Claude Code](https://claude.com/claude-code)