### PR TITLE
fix(claude.yml): switch to bun (repo doesn't use npm lockfile)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -29,9 +29,12 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: npm
 
-      - run: npm ci
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - run: bun install --frozen-lockfile
 
       - uses: anthropics/claude-code-action@v1
         with:


### PR DESCRIPTION
## Summary

`claude.yml` (PR #53) used `actions/setup-node@v4` with `cache: npm` + `npm ci`, which fails on this repo: there is no `package-lock.json` (the repo uses `bun.lock`).

Failing run: https://github.com/Pierre-Mike/agentic-journal/actions/runs/25131689397

Fix: drop `cache: npm`, add `oven-sh/setup-bun@v2`, run `bun install --frozen-lockfile`.

## Test plan
- [ ] CI passes
- [ ] Comment `@claude hi` on any open PR → workflow runs cleanly past the install step

🤖 Generated with [Claude Code](https://claude.com/claude-code)