### PR TITLE
fix(bootstrap): idempotent branch + PR on retrigger

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -35,21 +35,33 @@ jobs:
             | cut -c1-50)
           echo "value=$SLUG" >> $GITHUB_OUTPUT
 
-      - name: Create branch with seed commit
+      - name: Create or reuse branch (idempotent)
         run: |
           BRANCH="auto/${{ github.event.issue.number }}-${{ steps.slug.outputs.value }}"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
-          git checkout -b "$BRANCH"
-          git commit --allow-empty -m "bootstrap: open PR for issue #${{ github.event.issue.number }}"
-          git push -u origin "$BRANCH"
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            echo "Branch $BRANCH already exists on remote — checking out"
+            git fetch origin "$BRANCH"
+            git checkout -B "$BRANCH" "origin/$BRANCH"
+          else
+            echo "Creating new branch $BRANCH with seed commit"
+            git checkout -b "$BRANCH"
+            git commit --allow-empty -m "bootstrap: open PR for issue #${{ github.event.issue.number }}"
+            git push -u origin "$BRANCH"
+          fi
 
-      - name: Open draft PR linked to issue
+      - name: Open or reuse draft PR (idempotent)
         run: |
-          gh pr create \
-            --draft \
-            --title "auto: issue #${{ github.event.issue.number }} — ${{ github.event.issue.title }}" \
-            --body "Closes #${{ github.event.issue.number }}"
+          BRANCH="auto/${{ github.event.issue.number }}-${{ steps.slug.outputs.value }}"
+          if gh pr view "$BRANCH" --json number >/dev/null 2>&1; then
+            echo "PR for $BRANCH already exists — reusing"
+          else
+            gh pr create \
+              --draft \
+              --title "auto: issue #${{ github.event.issue.number }} — ${{ github.event.issue.title }}" \
+              --body "Closes #${{ github.event.issue.number }}"
+          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

When `issues.edited` or `issue_comment.created` retriggers bootstrap, the branch (and possibly the PR) already exists from the prior run. The previous flow always tried to create both, hitting:

- `git push -u origin <branch>` → `non-fast-forward` rejection
- `gh pr create` → `a pull request already exists for...`

Fix: detect existing branch and existing PR before creating; reuse when present.

## Test plan
- [x] `bun test tests/workflows/bootstrap.test.ts` 31/31 ✓
- [ ] Edit issue #55 again → bootstrap completes without push/PR conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)