### PR TITLE
fix: grant claude -p the tools it needs (Write/Edit/Bash)

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -79,7 +79,9 @@ jobs:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           ISSUE_BODY: ${{ github.event.issue.body }}
         run: |
-          claude -p "/do-auto $ISSUE_BODY" || true
+          claude -p "/do-auto $ISSUE_BODY" \
+            --allowedTools "Bash(git:*),Bash(gh:*),Bash(bun:*),Bash(mkdir:*),Bash(mv:*),Bash(cp:*),Bash(rm:*),Edit,Write,Read,Glob,Grep" \
+            || true
           if [ -f .agentic/last-alignment.md ]; then
             CONF=$(grep -E '^confidence:' .agentic/last-alignment.md | awk '{print $2}')
           else

--- a/.github/workflows/slice.yml
+++ b/.github/workflows/slice.yml
@@ -85,6 +85,7 @@ jobs:
             --no-resume \
             --max-turns 50 \
             --skill expertise \
+            --allowedTools "Bash(git:*),Bash(gh:*),Bash(bun:*),Bash(mkdir:*),Bash(mv:*),Bash(cp:*),Bash(rm:*),Edit,Write,Read,Glob,Grep" \
             "You are the spec-implementer. Make slice ${SLICE_ID} of spec ${SPEC_ID} GREEN. Read the frozen gate and implement only the file_targets declared in task ${SLICE_ID}. Run bun run tasks:verify. When GREEN, run a refactor pass scoped to the task's file_targets. Do not push — only commit."
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -125,6 +126,7 @@ jobs:
           claude -p \
             --no-resume \
             --max-turns 10 \
+            --allowedTools "Bash(git:*),Bash(bun:*),Edit,Write,Read,Glob,Grep" \
             "You are the spec-replanner. Slice ${SLICE_ID} of spec ${SPEC_ID} is now GREEN on branch ${BRANCH}. Review tasks.md and update the plan: check which slices are unblocked, update depends_on status, and commit any changes to tasks.md."
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Symptom

Bootstrap ran for 19 minutes on issue #61, the auto-aligner subagent internally returned \`confidence: high\` and produced a complete plan, but \`.agentic/last-alignment.md\` was never written. The bash check for that file fell through → \`CONF=low\` → low-confidence comment posted, no alignment committed, PR stayed empty.

## Root cause

Headless \`claude -p\` runs in a restricted tool mode by default. Without explicit \`--allowedTools\`, Write / Edit / Bash(git:*) / Bash(mkdir:*) etc. are blocked.

## Fix

Add \`--allowedTools "Bash(git:*),Bash(gh:*),Bash(bun:*),Bash(mkdir:*),Bash(mv:*),Bash(cp:*),Bash(rm:*),Edit,Write,Read,Glob,Grep"\` to every \`claude -p\` invocation in bootstrap.yml and slice.yml. Mirrors the wildfire_risk_portal_demo claude.yml pattern.

## Test plan
- [x] \`bun test tests/workflows/{bootstrap,slice}.test.ts\` 80/80 ✓
- [ ] Edit issue #61 → bootstrap actually writes alignment.md and commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)