### PR TITLE
chore: close the dispatch loop — controller scans auto/* branches

### DIFF
--- a/.github/workflows/controller.yml
+++ b/.github/workflows/controller.yml
@@ -1,5 +1,24 @@
 name: Slice Controller
 
+# Iterates over all `auto/*` branches that hold a scaffolded spec and
+# dispatches the next wave of ready slices for each. Idempotent — safe to
+# call as often as needed.
+#
+# Triggers:
+#   - cron every 2 min (safety net)
+#   - workflow_dispatch (manual)
+#   - repository_dispatch (legacy)
+#   - called from intent.yml after scaffold lands (instant first-wave dispatch)
+#   - called from slice.yml after each GREEN push (instant next-wave dispatch)
+#
+# Logic:
+#   for each remote branch matching `auto/*`:
+#     find specs/active/<spec>/tasks.md on that branch
+#     COMPLETED = slice IDs from `git log origin/main..origin/<branch>` GREEN commits
+#     IN_FLIGHT = slice.yml runs queued/in_progress for that branch
+#     DISPATCHABLE = bun scripts/dag-controller.ts <tasks.md> <COMPLETED> <IN_FLIGHT>
+#     for each id in DISPATCHABLE: gh workflow run slice.yml --field …
+
 on:
   schedule:
     - cron: "*/2 * * * *"
@@ -19,64 +38,81 @@ jobs:
   controller:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout main
         uses: actions/checkout@v4
         with:
+          ref: main
           fetch-depth: 0
+
+      - name: Fetch all auto/* branches
+        run: |
+          git fetch origin '+refs/heads/auto/*:refs/remotes/origin/auto/*' --prune || true
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 
-      - name: Detect completed slices from git log (GREEN commits)
-        id: completed
-        run: |
-          # Match commits like "code(049): GREEN — slice 3"
-          COMPLETED=$(git log --oneline | grep -oP 'GREEN\s+[—-]+\s+slice\s+\K\d+' | sort -un | tr '\n' ',' | sed 's/,$//')
-          echo "ids=${COMPLETED}" >> "$GITHUB_OUTPUT"
-
-      - name: Detect in-flight slice.yml runs
-        id: inflight
-        run: |
-          IN_FLIGHT=$(gh run list --workflow=slice.yml --status=in_progress --json databaseId,name 2>/dev/null || echo "[]")
-          echo "json=${IN_FLIGHT}" >> "$GITHUB_OUTPUT"
+      - name: Discover and dispatch per branch
         env:
           GH_TOKEN: ${{ github.token }}
-
-      - name: Compute dispatchable slices via dag-controller.ts
-        id: dag
         run: |
-          TASKS_MD=$(find specs/active -name "tasks.md" | head -1)
-          if [ -z "$TASKS_MD" ]; then
-            echo "dispatchable=[]" >> "$GITHUB_OUTPUT"
-            echo "spec_id=" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          AUTO_BRANCHES=$(git for-each-ref --format='%(refname:short)' 'refs/remotes/origin/auto/*' | sed 's|^origin/||' || true)
+          if [ -z "$AUTO_BRANCHES" ]; then
+            echo "No auto/* branches found."
             exit 0
           fi
-          SPEC_DIR=$(dirname "$TASKS_MD")
-          SPEC_ID=$(basename "$SPEC_DIR")
-          DISPATCHABLE=$(bun scripts/dag-controller.ts "$TASKS_MD" \
-            "${{ steps.completed.outputs.ids }}" \
-            '${{ steps.inflight.outputs.json }}')
-          echo "dispatchable=${DISPATCHABLE}" >> "$GITHUB_OUTPUT"
-          echo "spec_id=${SPEC_ID}" >> "$GITHUB_OUTPUT"
-        env:
-          GH_TOKEN: ${{ github.token }}
 
-      - name: Dispatch ready slices via gh workflow run slice.yml
-        if: steps.dag.outputs.dispatchable != '[]' && steps.dag.outputs.dispatchable != ''
-        run: |
-          DISPATCHABLE='${{ steps.dag.outputs.dispatchable }}'
-          SPEC_ID='${{ steps.dag.outputs.spec_id }}'
-          BRANCH='${{ github.ref_name }}'
-          # Iterate over slice IDs and dispatch each via gh api dispatches
-          for slice_id in $(echo "$DISPATCHABLE" | tr -d '[]' | tr ',' ' '); do
-            gh workflow run slice.yml \
-              --ref "$BRANCH" \
-              --field slice_id="${slice_id}" \
-              --field spec_id="${SPEC_ID}" \
-              --field branch="${BRANCH}"
-            echo "Dispatched slice_id=${slice_id} spec_id=${SPEC_ID} branch=${BRANCH}"
-          done
-        env:
-          GH_TOKEN: ${{ github.token }}
+          while IFS= read -r BRANCH; do
+            [ -z "$BRANCH" ] && continue
+            echo "::group::branch=$BRANCH"
+
+            # Locate tasks.md on the branch (single-spec assumption per branch)
+            TASKS_PATH=$(git ls-tree -r --name-only "origin/$BRANCH" 2>/dev/null \
+              | grep -E '^specs/active/[^/]+/tasks\.md$' | head -1 || true)
+            if [ -z "$TASKS_PATH" ]; then
+              echo "no tasks.md, skipping"
+              echo "::endgroup::"
+              continue
+            fi
+
+            # Materialise tasks.md content for the CLI
+            TMP_TASKS=$(mktemp)
+            git show "origin/$BRANCH:$TASKS_PATH" > "$TMP_TASKS"
+
+            # spec_id is the spec dir basename (e.g. "051-intent-status-…")
+            SPEC_ID=$(dirname "$TASKS_PATH" | xargs basename)
+
+            # Completed = GREEN commits on the branch ahead of main
+            COMPLETED=$(git log "origin/main..origin/$BRANCH" --oneline 2>/dev/null \
+              | grep -oP 'GREEN\s+[—-]+\s+slice\s+\K\d+' \
+              | sort -un | tr '\n' ',' | sed 's/,$//')
+
+            # In-flight = slice.yml runs queued/in_progress, scoped to this branch
+            IN_FLIGHT_QUEUED=$(gh run list --workflow=slice.yml --status=queued \
+              --branch="$BRANCH" --json databaseId,name 2>/dev/null || echo "[]")
+            IN_FLIGHT_RUNNING=$(gh run list --workflow=slice.yml --status=in_progress \
+              --branch="$BRANCH" --json databaseId,name 2>/dev/null || echo "[]")
+            IN_FLIGHT=$(jq -s 'add // []' <(echo "$IN_FLIGHT_QUEUED") <(echo "$IN_FLIGHT_RUNNING"))
+
+            # Compute dispatchable
+            DISPATCHABLE=$(bun scripts/dag-controller.ts "$TMP_TASKS" "$COMPLETED" "$IN_FLIGHT")
+            echo "spec=$SPEC_ID completed=[$COMPLETED] dispatchable=$DISPATCHABLE"
+
+            # Dispatch each ready slice
+            ISSUE_NUMBER=$(echo "$BRANCH" | grep -oE '^auto/[0-9]+' | grep -oE '[0-9]+' || true)
+            for slice_id in $(echo "$DISPATCHABLE" | tr -d '[]' | tr ',' ' '); do
+              [ -z "$slice_id" ] && continue
+              gh workflow run slice.yml \
+                --ref main \
+                --field slice_id="$slice_id" \
+                --field spec_id="$SPEC_ID" \
+                --field branch="$BRANCH" \
+                --field issue_number="$ISSUE_NUMBER"
+              echo "dispatched slice_id=$slice_id"
+            done
+
+            rm -f "$TMP_TASKS"
+            echo "::endgroup::"
+          done <<< "$AUTO_BRANCHES"

--- a/.github/workflows/intent.yml
+++ b/.github/workflows/intent.yml
@@ -281,11 +281,17 @@ jobs:
           fi
           git push origin "HEAD:$BRANCH"
 
+      - name: Trigger controller for instant first-wave dispatch
+        if: success()
+        run: gh workflow run controller.yml --ref main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Comment on issue (scaffold landed)
         if: success()
         run: |
           gh issue comment "${{ github.event.issue.number }}" \
-            --body "Spec scaffold landed on \`${{ needs.align.outputs.branch }}\`. Controller will pick up tasks.md within ~2 minutes and start dispatching slices."
+            --body "Spec scaffold landed on \`${{ needs.align.outputs.branch }}\`. Controller dispatched the first wave of slices."
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/slice.yml
+++ b/.github/workflows/slice.yml
@@ -136,6 +136,12 @@ jobs:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           GH_TOKEN: ${{ github.token }}
 
+      - name: Trigger controller for instant next-wave dispatch
+        if: success()
+        run: gh workflow run controller.yml --ref main
+        env:
+          GH_TOKEN: ${{ github.token }}
+
       - name: Failure escalation — post menu on issue
         if: failure() || steps.push.outputs.attempt == '3'
         run: |

--- a/scripts/dag-controller.ts
+++ b/scripts/dag-controller.ts
@@ -223,3 +223,58 @@ export function dispatchable(
 		return true;
 	});
 }
+
+// ---------------------------------------------------------------------------
+// CLI entrypoint
+// ---------------------------------------------------------------------------
+//
+// Usage: bun scripts/dag-controller.ts <tasks.md path> [completed-csv] [inflight-json]
+//
+//   tasks.md path    — required. Path to the spec's tasks.md.
+//   completed-csv    — comma-separated slice IDs already GREEN (e.g. "1,3").
+//                      Empty or missing = none.
+//   inflight-json    — JSON array from `gh run list --json databaseId,name`.
+//                      Names are matched against /slice[_\s]+id[=:]\s*(\d+)/i to
+//                      extract the in-flight slice IDs. Empty or "[]" = none.
+//
+// Prints a JSON array of dispatchable slice IDs to stdout, e.g. "[1,2]".
+// Exits 2 on usage error, 0 otherwise (including empty result).
+
+if (import.meta.main) {
+	const [tasksMdPath, completedArg = "", inFlightArg = "[]"] = process.argv.slice(2);
+	if (!tasksMdPath) {
+		console.error("usage: dag-controller.ts <tasks.md path> [completed-csv] [inflight-json]");
+		process.exit(2);
+	}
+	const raw = await Bun.file(tasksMdPath).text();
+	const tasks = parseTasksDag(raw);
+	const completed = new Set(
+		completedArg
+			? completedArg
+					.split(",")
+					.map((s) => s.trim())
+					.filter(Boolean)
+					.map(Number)
+					.filter((n) => Number.isFinite(n))
+			: [],
+	);
+	const taskById = new Map(tasks.map((t) => [t.id, t]));
+	let inFlight: InFlightEntry[] = [];
+	try {
+		const parsed = JSON.parse(inFlightArg);
+		if (Array.isArray(parsed)) {
+			inFlight = parsed
+				.map((r): InFlightEntry | null => {
+					const m = String(r.name ?? "").match(/slice[_\s]+id[=:]\s*(\d+)/i);
+					const id = m ? Number(m[1]) : Number.NaN;
+					const task = taskById.get(id);
+					return task ? { sliceId: id, touches: task.touches } : null;
+				})
+				.filter((e): e is InFlightEntry => e !== null);
+		}
+	} catch {
+		inFlight = [];
+	}
+	const ids = findDispatchable({ tasks, completed, inFlight });
+	console.log(JSON.stringify(ids));
+}


### PR DESCRIPTION
## Summary

Three pre-existing bugs blocked end-to-end issue→PR runs (zero `slice.yml` runs in repo history confirm the loop has never closed):

1. `controller.yml` checked out `main`; specs live on `auto/*`. `find specs/active -name tasks.md` always returned empty → `dispatchable=[]`.
2. `scripts/dag-controller.ts` had no CLI entry. `bun scripts/dag-controller.ts ...` ran the module silently and printed nothing — so even with the right `tasks.md`, controller saw an empty array.
3. Nothing kicked the controller after scaffold or after each GREEN except the 2-min cron, so the first slice always waited.

## Fixes

- **`scripts/dag-controller.ts`** — add `if (import.meta.main)` CLI block. Prints `JSON.stringify(findDispatchable(...))`. The frozen test gate exercises imports only, so it stays GREEN.
- **`.github/workflows/controller.yml`** — rewritten. Fetches all `auto/*` branches, iterates them, locates each spec's `tasks.md` via `git ls-tree`, computes COMPLETED from `git log main..auto/<n>` GREEN commits, computes IN_FLIGHT from `gh run list --branch=...`, runs the CLI, dispatches each ready slice. Idempotent.
- **`.github/workflows/intent.yml`** — after scaffold lands, fires `gh workflow run controller.yml` so the first wave dispatches immediately.
- **`.github/workflows/slice.yml`** — after the GREEN push + replanner succeed, fires `gh workflow run controller.yml` so the next wave dispatches immediately.

Cron stays at 2 min as a safety net.

## Test plan

- [ ] Merge → controller runs cron tick → picks up the live `auto/93-…` branch (issue #93 still open) → dispatches slice 1 → slice.yml runs → GREEN commits → controller dispatches slice 2 → automerge fires → PR #94 squash-merged → issue #93 closed.
- [ ] All 509 tests still green locally (verified pre-push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)