### PR TITLE
fix(slice): drop unsupported --skill flag, fix empty-body comment

### DIFF
--- a/.github/workflows/slice.yml
+++ b/.github/workflows/slice.yml
@@ -84,10 +84,9 @@ jobs:
           claude -p \
             --no-session-persistence \
             --max-turns 50 \
-            --skill expertise \
             --allowedTools "Bash(git:*),Bash(gh:*),Bash(bun:*),Bash(mkdir:*),Bash(mv:*),Bash(cp:*),Bash(rm:*),Edit,Write,Read,Glob,Grep" \
             <<EOF
-          You are the spec-implementer. Make slice ${SLICE_ID} of spec ${SPEC_ID} GREEN. Read the frozen gate and implement only the file_targets declared in task ${SLICE_ID}. Run bun run tasks:verify. When GREEN, run a refactor pass scoped to the task's file_targets. Do not push — only commit.
+          You are the spec-implementer. Make slice ${SLICE_ID} of spec ${SPEC_ID} GREEN. Read the frozen gate and implement only the file_targets declared in task ${SLICE_ID}. Run bun run tasks:verify. When GREEN, run a refactor pass scoped to the task's file_targets. Do not push — only commit. Use the expertise skill at .claude/skills/expertise/ if relevant patterns apply.
           EOF
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -152,7 +151,10 @@ jobs:
             echo "No issue_number provided; skipping gh issue comment"
             exit 0
           fi
-          MENU=$(bun scripts/issue-options.ts "${SPEC_ID}" "${SLICE_ID}" 2>/dev/null || echo "Slice ${SLICE_ID} failed after 3 retries.")
+          MENU=$(bun scripts/issue-options.ts "${SPEC_ID}" "${SLICE_ID}" 2>/dev/null || true)
+          if [ -z "${MENU}" ]; then
+            MENU="Slice ${SLICE_ID} of spec \`${SPEC_ID}\` failed. Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          fi
           gh issue comment "${ISSUE_NUMBER}" --body "${MENU}"
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary

Slice 1 of issue #93 dispatched but failed instantly:

\`\`\`
error: unknown option '--skill'
\`\`\`

Then the failure-escalation step crashed with:

\`\`\`
GraphQL: Body cannot be blank (addComment)
\`\`\`

## Fixes

- **\`--skill expertise\`** — claude CLI has no such flag. Skills auto-resolve from \`.claude/skills/\` when present in CWD. Move the expertise hint into the prompt body.
- **Failure-escalation empty body** — when \`bun scripts/issue-options.ts\` exits 0 but prints nothing, MENU is empty and \`gh issue comment --body ""\` fails. Add an explicit empty-string check + run-URL fallback.

## Test plan

- [ ] Merge → re-trigger controller → slice 1 actually runs claude → spec-implementer makes the gate GREEN → push → controller fires next wave (slice 2) → automerge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)