### PR TITLE
fix(controller): dedupe in-flight slice runs via displayTitle

### DIFF
--- a/.github/workflows/controller.yml
+++ b/.github/workflows/controller.yml
@@ -107,12 +107,24 @@ jobs:
                   | sed 's/,$//'; } || true
             )
 
-            # In-flight slice.yml runs scoped to this branch
+            # In-flight slice.yml runs.
+            #
+            # slice.yml's `gh workflow run --ref main --field branch=...`
+            # invocation produces runs with headBranch=main (since the
+            # workflow file lives on main). The auto/* branch is just an
+            # input. To filter by branch, we parse the run-name string
+            # (which embeds slice/spec/branch — see slice.yml top-of-file).
             IN_FLIGHT_QUEUED=$(gh run list --workflow=slice.yml --status=queued \
-              --branch="$BRANCH" --json databaseId,name 2>/dev/null || echo "[]")
+              --json databaseId,displayTitle 2>/dev/null || echo "[]")
             IN_FLIGHT_RUNNING=$(gh run list --workflow=slice.yml --status=in_progress \
-              --branch="$BRANCH" --json databaseId,name 2>/dev/null || echo "[]")
-            IN_FLIGHT=$(jq -s 'add // []' <(echo "$IN_FLIGHT_QUEUED") <(echo "$IN_FLIGHT_RUNNING") 2>/dev/null || echo "[]")
+              --json databaseId,displayTitle 2>/dev/null || echo "[]")
+            IN_FLIGHT_ALL=$(jq -s 'add // []' <(echo "$IN_FLIGHT_QUEUED") <(echo "$IN_FLIGHT_RUNNING") 2>/dev/null || echo "[]")
+            # Keep only runs whose displayTitle mentions THIS branch and
+            # rewrite into the {name: "slice_id=N"} shape dag-controller's
+            # CLI parses (see scripts/dag-controller.ts CLI block).
+            IN_FLIGHT=$(echo "$IN_FLIGHT_ALL" | jq --arg branch "$BRANCH" \
+              '[.[] | select(.displayTitle | contains($branch)) | {name: ("slice_id=" + ((.displayTitle | capture("slice (?<id>[0-9]+)").id) // "0"))}]' \
+              2>/dev/null || echo "[]")
 
             # Compute dispatchable
             DISPATCHABLE=$(bun scripts/dag-controller.ts "$TMP_TASKS" "$COMPLETED" "$IN_FLIGHT" 2>/dev/null || echo "[]")

--- a/.github/workflows/slice.yml
+++ b/.github/workflows/slice.yml
@@ -1,5 +1,10 @@
 name: Slice Runner
 
+# run-name embeds slice/spec/branch identifiers so the controller can parse
+# them from `gh run list --json name` to detect duplicates without needing
+# per-run API calls.
+run-name: "slice ${{ inputs.slice_id || github.event.client_payload.slice_id }} of ${{ inputs.spec_id || github.event.client_payload.spec_id }} on ${{ inputs.branch || github.event.client_payload.branch }}"
+
 on:
   repository_dispatch:
     types: [slice-ready]


### PR DESCRIPTION
## Summary

Discovered while watching issue #93's pipeline: every controller cron tick was re-dispatching slice 1 while the previous slice 1 run was still in_progress, queueing duplicate runs.

## Root cause

`gh workflow run --ref main --field branch=auto/...` produces slice.yml runs whose `headBranch` is `main` (where the workflow file lives), **not** the auto branch. The controller's `gh run list --branch=auto/...` filter therefore matched zero runs, IN_FLIGHT was always `[]`, and the dag-controller saw nothing in flight.

## Fix

- **`slice.yml`** — add a top-of-file `run-name:` that embeds slice_id, spec_id, and target branch: `"slice 1 of 051-foo on auto/93-bar"`. Gives the controller a stable identifier without per-run API calls.
- **`controller.yml`** — query `displayTitle` instead of `--branch`, filter by branch substring, then re-emit a `{name: "slice_id=N"}` shape that dag-controller's CLI already parses via `/slice[_\s]+id[=:]\s*(\d+)/i`.

## Test plan

- [ ] Merge → next controller cron tick sees slice 1 in_progress → does NOT re-dispatch slice 1 → slice 1 GREEN → controller dispatches slice 2 (and only slice 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)