### PR TITLE
fix(slice): set git identity in marker-commit step

### DIFF
--- a/.github/workflows/slice.yml
+++ b/.github/workflows/slice.yml
@@ -105,6 +105,12 @@ jobs:
         run: |
           SLICE_ID="${{ steps.norm.outputs.slice_id }}"
           SPEC_ID="${{ steps.norm.outputs.spec_id }}"
+          # Set git identity defensively. Claude sets its own identity
+          # for its commits, but `git commit --allow-empty` here runs in
+          # a fresh shell and inherits nothing — slice 2 of issue #101
+          # crashed with `Author identity unknown` because of this.
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
           # The spec-implementer may have already committed its work with
           # any message format. The controller's COMPLETED detection greps
           # for `GREEN — slice N` in commit subjects, so we always lay


### PR DESCRIPTION
## Summary

Slice 2 of issue #101 crashed in the new `Ensure GREEN marker commit exists` step:

```
fatal: empty ident name (for <runner@…internal.cloudapp.net>) not allowed
```

## Root cause

Claude (the spec-implementer) sets its own git identity per-invocation, but the marker step's `git commit --allow-empty` runs in a fresh shell that inherits nothing. Slice 1 didn't trip this because claude happened to commit with a subject already matching `GREEN — slice 1`, so the fallback `git commit` was skipped. Slice 2's commit subject was different, the fallback fired, and there was no identity to use.

## Fix

Set `user.email` / `user.name` defensively at the start of the marker step. Same pattern as the scaffold + alignment steps in `intent.yml`.

## Test plan

- [ ] Merge → trigger controller → slice 2 of spec 052 re-dispatches → marker commit lands → push → automerge cascade → PR #102 squashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)