### PR TITLE
fix(_lib): recognize YAML-list tasks.md format in taskGates

### DIFF
--- a/scripts/_lib.test.ts
+++ b/scripts/_lib.test.ts
@@ -10,7 +10,14 @@ import { describe, expect, test } from "bun:test";
 import { closeSync, mkdtempSync, openSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { gateEntries, gatePaths, isReady, sliceProgress, unresolvedDeps } from "./_lib.ts";
+import {
+	gateEntries,
+	gatePaths,
+	isReady,
+	sliceProgress,
+	taskGates,
+	unresolvedDeps,
+} from "./_lib.ts";
 
 const makeSpec = (gate: unknown, depends_on: string[] = []) => ({
 	slug: "test",
@@ -159,5 +166,53 @@ describe("sliceProgress", () => {
 	test("kind:code, 0 tasks with gate fields → null", () => {
 		const dir = makeFixtureSpecDir("code", 0, []);
 		expect(sliceProgress({ specDir: dir })).toBeNull();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// taskGates — YAML-list task format (the format the spec-tester emits)
+// ---------------------------------------------------------------------------
+
+describe("taskGates: YAML-list format", () => {
+	function makeYamlListSpec(opts: { gates: readonly string[]; frozen: readonly number[] }): string {
+		const dir = mkdtempSync(join(tmpdir(), "spec-yaml-"));
+		const lines: string[] = ["## Tasks", ""];
+		opts.gates.forEach((gate, i) => {
+			const id = i + 1;
+			lines.push(`- id: ${id}`);
+			lines.push(`  title: "Task ${id}"`);
+			lines.push(`  agent: main`);
+			lines.push(`  depends_on: []`);
+			lines.push(`  gate: ${gate}`);
+			lines.push("");
+		});
+		writeFileSync(join(dir, "tasks.md"), lines.join("\n"), "utf-8");
+		for (const ord of opts.frozen) {
+			closeSync(openSync(join(dir, `.gate-frozen-${ord}`), "w"));
+		}
+		return dir;
+	}
+
+	test("returns one entry per YAML-list task with a gate field", () => {
+		const dir = makeYamlListSpec({
+			gates: ["scripts/a.test.ts", "tests/b.test.ts"],
+			frozen: [],
+		});
+		const result = taskGates(dir);
+		expect(result.length).toBe(2);
+		expect(result[0]?.ordinal).toBe(1);
+		expect(result[0]?.gatePath).toBe("scripts/a.test.ts");
+		expect(result[1]?.ordinal).toBe(2);
+		expect(result[1]?.gatePath).toBe("tests/b.test.ts");
+	});
+
+	test("frozen sentinel detection works for YAML-list specs", () => {
+		const dir = makeYamlListSpec({
+			gates: ["scripts/a.test.ts", "tests/b.test.ts"],
+			frozen: [1],
+		});
+		const result = taskGates(dir);
+		expect(result[0]?.frozen).toBe(true);
+		expect(result[1]?.frozen).toBe(false);
 	});
 });

--- a/scripts/_lib.ts
+++ b/scripts/_lib.ts
@@ -221,7 +221,9 @@ export function sliceProgress({ specDir }: { specDir: string }): SliceProgress |
  * starting at 1. The `frozen` field is true if the corresponding
  * `.gate-frozen-N` sentinel file exists in `specDir`.
  *
- * Only applies to `kind: code` specs. For other kinds, returns [].
+ * Recognizes both task formats:
+ *   - markdown checkbox: `- [ ] Task title` followed by `  - gate: path`
+ *   - YAML list:         `- id: N`           followed by `  gate: path`
  */
 export function taskGates(specDir: string): readonly TaskGateEntry[] {
 	const tasksPath = join(specDir, "tasks.md");
@@ -233,13 +235,15 @@ export function taskGates(specDir: string): readonly TaskGateEntry[] {
 	let inTask = false;
 
 	for (const line of lines) {
-		const taskMatch = line.match(/^- \[[ x]\]\s+.+$/);
+		const taskMatch =
+			line.match(/^- \[[ x]\]\s+.+$/) !== null || line.match(/^- id:\s*\d+/) !== null;
 		if (taskMatch) {
 			inTask = true;
 			continue;
 		}
 		if (!inTask) continue;
-		const gateMatch = line.match(/^\s+-\s+gate:\s*(.+)$/);
+		// Match `  - gate: path` (markdown-checkbox style) or `  gate: path` (YAML-list style).
+		const gateMatch = line.match(/^\s+(?:-\s+)?gate:\s*(.+)$/);
 		if (gateMatch) {
 			ordinal += 1;
 			const gatePath = (gateMatch[1] ?? "").trim();


### PR DESCRIPTION
## Summary

`taskGates()` in `scripts/_lib.ts` only recognized markdown-checkbox tasks (`- [ ] title` with `  - gate: path`). The spec-tester emits YAML-list tasks (`- id: N` with `  gate: path`) — that's the production format used by every recent kind:code spec. So `taskGates` returned `[]`, the slice-aware branch in `tasks-verify` was skipped, and the verifier fell through to running **every** gate path in `proposal.md` — including the integration gate for unbuilt slices.

CI on PR #118 fails on `tests/pipeline-report-bdd.test.ts` (slice 2's gate) even though only slice 1 has shipped.

## Changes

- `scripts/_lib.ts`: extend `taskGates` to also match `^- id:\s*\d+` task headers and `^\s+gate:` (no leading dash) gate lines.
- `scripts/_lib.test.ts`: add YAML-list fixture tests for `taskGates` covering both gate enumeration and frozen-sentinel detection.

## Test plan

- [x] `bun test scripts/_lib.test.ts` — 20 pass / 0 fail (was 18 pass before)
- [x] `bun run tasks:verify` on PR #118's branch with this fix → green ("scaffold state — no slices frozen yet (RED is correct)")
- [x] `bun run typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)