### PR TITLE
fix(pipeline): scope dag_done to PR branch, fixes premature archive (unblocks #124)

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -77,16 +77,21 @@ jobs:
             exit 0
           fi
 
-          # Fetch slice IDs from tasks.md (find the active spec)
-          SPEC_DIR=$(find specs/active -name tasks.md 2>/dev/null | head -1)
-          if [ -z "${SPEC_DIR}" ]; then
-            echo "No tasks.md found; assuming DAG done" >&2
-            echo "dag_done=true" >> "$GITHUB_OUTPUT"
+          # Read tasks.md from the PR branch — NOT the local checkout, which is
+          # main and won't contain the in-flight spec. Looking on main caused
+          # the previous "no tasks.md, assume DAG done" path to fire and
+          # archive specs after the first slice.
+          git fetch origin "${BRANCH}" --quiet
+          SPEC_PATH=$(git ls-tree --name-only -r "origin/${BRANCH}" -- specs/active/ 2>/dev/null | grep -E '/tasks\.md$' | head -1)
+          if [ -z "${SPEC_PATH}" ]; then
+            echo "No tasks.md on PR branch '${BRANCH}'; spec missing — DAG not done." >&2
+            echo "dag_done=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          # Extract all slice IDs from tasks.md
-          SLICE_IDS=$(grep -oP '(?<=^- id: )\d+' "${SPEC_DIR}" | sort -n)
+          # Extract all slice IDs from tasks.md (read content from the PR branch)
+          TASKS_MD=$(git show "origin/${BRANCH}:${SPEC_PATH}")
+          SLICE_IDS=$(echo "${TASKS_MD}" | grep -oP '(?<=^- id: )\d+' | sort -n)
           if [ -z "${SLICE_IDS}" ]; then
             echo "No slice IDs found in tasks.md" >&2
             echo "dag_done=false" >> "$GITHUB_OUTPUT"

--- a/tests/workflows/automerge.test.ts
+++ b/tests/workflows/automerge.test.ts
@@ -251,6 +251,29 @@ describe("automerge.yml: aggregator gate — DAG done check", () => {
 			(dagDoneStep?.run?.includes("GITHUB_OUTPUT") ?? false) || dagDoneStep?.id !== undefined;
 		expect(writesOutput).toBe(true);
 	});
+
+	test("DAG-done step reads tasks.md from the PR branch (not local checkout)", () => {
+		// Regression: previously used `find specs/active -name tasks.md`, which
+		// only sees main's working tree (default workflow_run checkout). On
+		// in-flight PRs the spec lives on auto/X, so find returned empty and
+		// the fallback path archived prematurely after slice 1.
+		const wf = parseWorkflow();
+		const steps = allSteps(wf);
+		const dagDoneStep = steps.find((s) => s.id === "dag_done");
+		expect(dagDoneStep).toBeDefined();
+		const run = dagDoneStep?.run ?? "";
+		// Must read tasks.md from the PR branch via git, not via `find` on the
+		// local checkout. Either `git show origin/${BRANCH}:` or
+		// `git ls-tree origin/${BRANCH}` is acceptable.
+		const readsFromBranch =
+			run.includes('git show "origin/${BRANCH}') ||
+			run.includes("git ls-tree") ||
+			run.includes("origin/${BRANCH}:");
+		expect(readsFromBranch).toBe(true);
+		// Must NOT fall back to "assume DAG done" on missing tasks.md — that's
+		// the bug that caused premature archive.
+		expect(run).not.toMatch(/assuming DAG done/i);
+	});
 });
 
 describe("automerge.yml: aggregator gate — outer BDD gate", () => {


### PR DESCRIPTION
## Summary

The aggregator's `dag_done` step in `automerge.yml` read `tasks.md` from the local checkout — which is `main` for `workflow_run`-triggered jobs. On in-flight PRs the spec dir only exists on the `auto/X` branch, so `find specs/active -name tasks.md` returned empty and the fallback path **set `dag_done=true`** with a `"No tasks.md found; assuming DAG done"` log.

Result: every multi-slice spec was archived after **slice 1**. The controller then logged `no tasks.md, skipping` and never dispatched slice 2..N. PRs got stuck mid-build with their outer BDD gate RED.

## Reproduced on PR #124 (issue #123)

```
auto/123-...  commits:
  scaffold (3-slice plan)
  GREEN — slice 1
  chore(123): archive spec     ← FIRED PREMATURELY (this PR fixes that step)
  GREEN — slice 2              ← already in flight
  (slice 3 never dispatched — controller sees no active spec)
```

## Fix

- Read `tasks.md` directly from the PR branch via `git ls-tree`/`git show origin/\${BRANCH}:` instead of `find` on local checkout.
- Drop the dangerous "assume DAG done" fallback. Missing `tasks.md` now correctly leaves `dag_done=false`.

## Test plan

- [x] `bun test tests/workflows/automerge.test.ts` — 38 pass / 0 fail (new regression test added)
- [x] `bun run typecheck` clean
- [ ] On merge: rerun controller for `auto/123-...` so slice 3 dispatches and PR #124 unblocks (will be a follow-up: this PR's fix only prevents *future* premature archives; #124 still needs its archived spec dir restored on the auto/123 branch)

## Follow-up needed for PR #124

Even after this lands, PR #124's spec dir is in `specs/archive/` on its branch. Restoring it (revert commit `77ca7dd` on `auto/123-...`) lets the controller pick slice 3 back up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)